### PR TITLE
add on_screen property

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,21 +93,21 @@ Each monitor will have a sub array, workspaces, which will be the same informati
    {
       "name": "eDP-1",
       "workspaces": [
-         {"active": false,"class": "workspace-button w6","id": 6,"name": "6 []"}
+         {"active": false,"class": "workspace-button w6 workspace-on-screen","id": 6,"name": "6 []"}
       ]
    },
    {
       "name": "DP-3",
       "workspaces": [
          {"active": false,"class": "workspace-button w1","id": 1,"name": "1 "},
-         {"active": true,"class": "workspace-button w3 workspace-active wa3","id": 3,"name": "3 "}
+         {"active": true,"class": "workspace-button w3 workspace-active wa3 workspace-on-screen","id": 3,"name": "3 "}
       ]
    },
    {
       "name": "DP-4",
       "workspaces": [
          {"active": false,"class": "workspace-button w2","id": 2,"name": "2 "},
-         {"active": false,"class": "workspace-button w5","id": 5,"name": "5 "}
+         {"active": false,"class": "workspace-button w5 workspace-on-screen","id": 5,"name": "5 "}
       ]
    }
 ]
@@ -143,3 +143,4 @@ The following classes are output, to provide multiple options for theming your w
 * `workspace-active`: only the active workspace will have this class. Will not be present if workspace is active, but focus is on another monitor.
 * `w<WORKSPACEID>`: Each workspace will have this class to allow for unique CSS per workspace.
 * `wa<WORKSPACEID>`: The active workspace will have this to allow for unique CSS per workspace, when it is active. Like `workspace-active`, this does not appear when the focus is on another monitor.
+* `workspace-on-screen`: a workspace will have this class if it's currently displayed on a monitor.

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn get_workspace_windows(monitor: &str) -> Result<Vec<WorkspaceCustom>> {
     {
         let mut active = false;
         let on_screen = on_screen_workspaces.contains(&workspace.id);
-        let mut class = format!("workspace-button w{}{}", workspace.id, if on_screen {" on-screen"} else {""});
+        let mut class = format!("workspace-button w{}{}", workspace.id, if on_screen {" workspace-on-screen"} else {""});
         if (active_workspace_id == workspace.id)
             && (active_monitor_name == monitor || monitor == "ALL")
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ struct WorkspaceCustom {
     pub name: String,
     pub id: i32,
     pub active: bool,
+    pub on_screen: bool,
     pub class: String,
 }
 
@@ -66,6 +67,9 @@ fn get_workspace_windows(monitor: &str) -> Result<Vec<WorkspaceCustom>> {
             HyprError::NotOkDispatch("No active monitor found".to_string())
         })?
         .name;
+    let on_screen_workspaces: Vec<i32> = Monitors::get()?
+        .into_iter()
+        .map(|m| m.active_workspace.id).collect();
     let mut out_workspaces: Vec<WorkspaceCustom> = Vec::new();
 
     for workspace in workspaces
@@ -73,8 +77,9 @@ fn get_workspace_windows(monitor: &str) -> Result<Vec<WorkspaceCustom>> {
         .filter(|m| m.monitor == monitor || monitor == "ALL" || monitor == "_")
     {
         let mut active = false;
-        let mut class = format!("workspace-button w{}", workspace.id);
-        if active_workspace_id == workspace.id
+        let on_screen = on_screen_workspaces.contains(&workspace.id);
+        let mut class = format!("workspace-button w{}{}", workspace.id, if on_screen {" on-screen"} else {""});
+        if (active_workspace_id == workspace.id)
             && (active_monitor_name == monitor || monitor == "ALL")
         {
             class = format!("{} workspace-active wa{}", class, workspace.id);
@@ -85,6 +90,7 @@ fn get_workspace_windows(monitor: &str) -> Result<Vec<WorkspaceCustom>> {
             name: workspace.name.clone(),
             id: workspace.id,
             active,
+            on_screen,
             class,
         };
         out_workspaces.push(ws);


### PR DESCRIPTION
 add an 'on screen' property to identify screen that are currently displayed on all screens to allow styling actually displayed screen to be stylized even on non curently active workspace. ex: two screen with multiple workspace, quicly identify what worskapce is displayed on the secondary non focused screen.