### PR TITLE
Remove workspace-button from output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ fn get_workspace_windows(monitor: &str) -> Result<Vec<WorkspaceCustom>> {
         if (active_workspace_id == workspace.id)
             && (active_monitor_name == monitor || monitor == "ALL")
         {
-            class = format!("{} workspace-active wa{}", class, workspace.id);
+            class = format!("workspace-active wa{}", workspace.id);
             active = true;
         }
 


### PR DESCRIPTION
I removed workspace-button from output because eww can't use different padding (atleast my build from AUR) when item has multiple classes